### PR TITLE
kernel: timeconst.pl fix

### DIFF
--- a/drivers/staging/iio/light/ltr558als.c
+++ b/drivers/staging/iio/light/ltr558als.c
@@ -9,7 +9,9 @@
  */
 
 #include <linux/delay.h>
+#ifdef CONFIG_HAS_EARLYSUSPEND
 #include <linux/earlysuspend.h>
+#endif
 #include <linux/fs.h>
 #include <linux/i2c.h>
 #include <linux/init.h>

--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -369,8 +369,10 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	$cv = $canned_values{$hz};
-	@val = defined($cv) ? @$cv : compute_values($hz);
+	@val = @{$canned_values{$hz}};
+	if (!@val) {
+	@val = compute_values($hz);
+	}
 	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
I got this error msg when trying to build firmware with your kernels
```
  TIMEC   kernel/timeconst.h
Can't use 'defined(@array)' (Maybe you should just omit the defined()?) at /home/sudokamikaze/Git/RR_MM/kernel/asus/grouper/kernel/timeconst.pl line 373.
make[3]: *** [/home/sudokamikaze/Git/RR_MM/kernel/asus/grouper/kernel/Makefile:140: kernel/timeconst.h] Error 255
make[2]: *** [/home/sudokamikaze/Git/RR_MM/kernel/asus/grouper/Makefile:945: kernel] Error 2
make[2]: *** Waiting for unfinished jobs....
```
And i made a fix